### PR TITLE
feat(issue-132): display skeleton loading for the connections tab during initial fetching

### DIFF
--- a/src/dictionaries/en.ts
+++ b/src/dictionaries/en.ts
@@ -7,6 +7,8 @@ export const dictionary = {
   },
   COMMON: {
     APP_NAME: 'Coding For Fun',
+    ALERT_NO_DATA_TITLE: 'No Data',
+    ALERT_NO_DATA_DESCRIPTION: 'There are no data to display',
     ALERT_DEFAULT_SUCCESS_TITLE: 'Success',
     ALERT_DEFAULT_ERROR_TITLE: 'Error',
     TOAST_DEFAULT_SUCCESS_TITLE: 'Success',

--- a/src/elements/table/table.test.tsx
+++ b/src/elements/table/table.test.tsx
@@ -1,118 +1,249 @@
 import { render, screen, within } from '@/utils/root/test/testing-library'
 
-import { Table } from './table'
+import {
+  SKELETON_ROW_LENGTH,
+  Table,
+  TableBodyContent,
+  TableSkeleton
+} from './table'
+
+const tableHeaders = [
+  {
+    key: 'header-0',
+    className: 'header-0-class',
+    items: [
+      {
+        key: 'header-0-item-0',
+        className: 'header-0-item-0-class',
+        children: 'header-0-item-0-text'
+      },
+      {
+        key: 'header-0-item-1',
+        className: 'header-0-item-1-class',
+        children: 'header-0-item-1-text'
+      },
+      {
+        key: 'header-0-item-2',
+        className: 'header-0-item-2-class',
+        children: 'header-0-item-2-text'
+      }
+    ]
+  },
+  {
+    key: 'header-1',
+    className: 'header-1-class',
+    items: [
+      {
+        key: 'header-1-item-0',
+        className: 'header-1-item-0-class',
+        children: 'header-1-item-0-text'
+      },
+      {
+        key: 'header-1-item-1',
+        className: 'header-1-item-1-class',
+        children: 'header-1-item-1-text'
+      },
+      {
+        key: 'header-1-item-2',
+        className: 'header-1-item-2-class',
+        children: 'header-1-item-2-text'
+      }
+    ]
+  }
+]
+const tableCells = [
+  {
+    key: 'cell-0',
+    className: 'cell-0-class',
+    items: [
+      {
+        key: 'cell-0-item-0',
+        className: 'cell-0-item-0-class',
+        children: 'cell-0-item-0-text'
+      },
+      {
+        key: 'cell-0-item-1',
+        className: 'cell-0-item-1-class',
+        children: 'cell-0-item-1-text'
+      },
+      {
+        key: 'cell-0-item-2',
+        className: 'cell-0-item-2-class',
+        children: 'cell-0-item-2-text'
+      }
+    ]
+  },
+  {
+    key: 'cell-1',
+    className: 'cell-1-class',
+    items: [
+      {
+        key: 'cell-1-item-0',
+        className: 'cell-1-item-0-class',
+        children: 'cell-1-item-0-text'
+      },
+      {
+        key: 'cell-1-item-1',
+        className: 'cell-1-item-1-class',
+        children: 'cell-1-item-1-text'
+      },
+      {
+        key: 'cell-1-item-2',
+        className: 'cell-1-item-2-class',
+        children: 'cell-1-item-2-text'
+      }
+    ]
+  },
+  {
+    key: 'cell-2',
+    className: 'cell-2-class',
+    items: [
+      {
+        key: 'cell-2-item-0',
+        className: 'cell-2-item-0-class',
+        children: 'cell-2-item-0-text'
+      },
+      {
+        key: 'cell-2-item-1',
+        className: 'cell-2-item-1-class',
+        children: 'cell-2-item-1-text'
+      },
+      {
+        key: 'cell-2-item-2',
+        className: 'cell-2-item-2-class',
+        children: 'cell-2-item-2-text'
+      }
+    ]
+  }
+]
+
+const testSkeletonLoad = (header: (typeof tableHeaders)[0]) => {
+  const rows = screen.getAllByRole('row')
+  expect(rows).toHaveLength(SKELETON_ROW_LENGTH)
+  rows.forEach((row) => {
+    expect(row).toHaveClass(header.className)
+
+    const cells = within(row).getAllByRole('cell')
+    expect(cells).toHaveLength(3)
+
+    cells.forEach((cell, index) => {
+      expect(cell).toHaveClass(header.items[index]!.className)
+      expect(cell.querySelector('.skeleton')).not.toBeNull()
+    })
+  })
+}
+
+describe('TableSkeleton', () => {
+  it('should load SKELETON_ROW_LENGTH rows skeleton', () => {
+    render(
+      <table>
+        <tbody>
+          <TableSkeleton header={tableHeaders[0]} />
+        </tbody>
+      </table>
+    )
+
+    const rows = screen.getAllByRole('row')
+    expect(rows).toHaveLength(SKELETON_ROW_LENGTH)
+    rows.forEach((row) => {
+      const cells = within(row).getAllByRole('cell')
+      expect(cells).toHaveLength(3)
+
+      cells.forEach((cell) => {
+        expect(cell.querySelector('.skeleton')).not.toBeNull()
+      })
+    })
+  })
+
+  it('should have first header row class and each item class', () => {
+    const firstHeader = tableHeaders[0]
+
+    render(
+      <table>
+        <tbody>
+          <TableSkeleton header={firstHeader} />
+        </tbody>
+      </table>
+    )
+
+    testSkeletonLoad(firstHeader!)
+  })
+})
+
+describe('TableBodyContent', () => {
+  it('should render skeleton if cells are undefined', () => {
+    render(
+      <table>
+        <tbody>
+          <TableBodyContent headers={tableHeaders} cells={undefined} />
+        </tbody>
+      </table>
+    )
+
+    testSkeletonLoad(tableHeaders[0]!)
+  })
+
+  it('should render info alert message', () => {
+    render(
+      <table>
+        <tbody>
+          <TableBodyContent headers={tableHeaders} cells={[]} />
+        </tbody>
+      </table>
+    )
+
+    expect(screen.getByTestId('info-circled-icon')).toBeInTheDocument()
+    expect(screen.getByText('COMMON.ALERT_NO_DATA_TITLE')).toBeInTheDocument()
+    expect(
+      screen.getByText('COMMON.ALERT_NO_DATA_DESCRIPTION')
+    ).toBeInTheDocument()
+  })
+
+  it('should tableCells data as expected if cells.length > 0', () => {
+    render(
+      <table>
+        <tbody>
+          <TableBodyContent headers={tableHeaders} cells={tableCells} />
+        </tbody>
+      </table>
+    )
+
+    const rows = screen.getAllByRole('row')
+    expect(rows).toHaveLength(3)
+
+    expect(rows[0]).toHaveClass('cell-0-class')
+    const row0cells = within(rows[0]!).getAllByRole('cell')
+    expect(row0cells).toHaveLength(3)
+    expect(row0cells[0]).toHaveTextContent('cell-0-item-0-text')
+    expect(row0cells[0]).toHaveClass('cell-0-item-0-class')
+    expect(row0cells[1]).toHaveTextContent('cell-0-item-1-text')
+    expect(row0cells[1]).toHaveClass('cell-0-item-1-class')
+    expect(row0cells[2]).toHaveTextContent('cell-0-item-2-text')
+    expect(row0cells[2]).toHaveClass('cell-0-item-2-class')
+
+    expect(rows[1]).toHaveClass('cell-1-class')
+    const row1cells = within(rows[1]!).getAllByRole('cell')
+    expect(row1cells).toHaveLength(3)
+    expect(row1cells[0]).toHaveTextContent('cell-1-item-0-text')
+    expect(row1cells[0]).toHaveClass('cell-1-item-0-class')
+    expect(row1cells[1]).toHaveTextContent('cell-1-item-1-text')
+    expect(row1cells[1]).toHaveClass('cell-1-item-1-class')
+    expect(row1cells[2]).toHaveTextContent('cell-1-item-2-text')
+    expect(row1cells[2]).toHaveClass('cell-1-item-2-class')
+
+    expect(rows[2]).toHaveClass('cell-2-class')
+    const row2cells = within(rows[2]!).getAllByRole('cell')
+    expect(row2cells).toHaveLength(3)
+    expect(row2cells[0]).toHaveTextContent('cell-2-item-0-text')
+    expect(row2cells[0]).toHaveClass('cell-2-item-0-class')
+    expect(row2cells[1]).toHaveTextContent('cell-2-item-1-text')
+    expect(row2cells[1]).toHaveClass('cell-2-item-1-class')
+    expect(row2cells[2]).toHaveTextContent('cell-2-item-2-text')
+    expect(row2cells[2]).toHaveClass('cell-2-item-2-class')
+  })
+})
 
 describe('Table', () => {
-  const tableHeaders = [
-    {
-      key: 'header-0',
-      className: 'header-0-class',
-      items: [
-        {
-          key: 'header-0-item-0',
-          className: 'header-0-item-0-class',
-          children: 'header-0-item-0-text'
-        },
-        {
-          key: 'header-0-item-1',
-          className: 'header-0-item-1-class',
-          children: 'header-0-item-1-text'
-        },
-        {
-          key: 'header-0-item-2',
-          className: 'header-0-item-2-class',
-          children: 'header-0-item-2-text'
-        }
-      ]
-    },
-    {
-      key: 'header-1',
-      className: 'header-1-class',
-      items: [
-        {
-          key: 'header-1-item-0',
-          className: 'header-1-item-0-class',
-          children: 'header-1-item-0-text'
-        },
-        {
-          key: 'header-1-item-1',
-          className: 'header-1-item-1-class',
-          children: 'header-1-item-1-text'
-        },
-        {
-          key: 'header-1-item-2',
-          className: 'header-1-item-2-class',
-          children: 'header-1-item-2-text'
-        }
-      ]
-    }
-  ]
-  const tableCells = [
-    {
-      key: 'cell-0',
-      className: 'cell-0-class',
-      items: [
-        {
-          key: 'cell-0-item-0',
-          className: 'cell-0-item-0-class',
-          children: 'cell-0-item-0-text'
-        },
-        {
-          key: 'cell-0-item-1',
-          className: 'cell-0-item-1-class',
-          children: 'cell-0-item-1-text'
-        },
-        {
-          key: 'cell-0-item-2',
-          className: 'cell-0-item-2-class',
-          children: 'cell-0-item-2-text'
-        }
-      ]
-    },
-    {
-      key: 'cell-1',
-      className: 'cell-1-class',
-      items: [
-        {
-          key: 'cell-1-item-0',
-          className: 'cell-1-item-0-class',
-          children: 'cell-1-item-0-text'
-        },
-        {
-          key: 'cell-1-item-1',
-          className: 'cell-1-item-1-class',
-          children: 'cell-1-item-1-text'
-        },
-        {
-          key: 'cell-1-item-2',
-          className: 'cell-1-item-2-class',
-          children: 'cell-1-item-2-text'
-        }
-      ]
-    },
-    {
-      key: 'cell-2',
-      className: 'cell-2-class',
-      items: [
-        {
-          key: 'cell-2-item-0',
-          className: 'cell-2-item-0-class',
-          children: 'cell-2-item-0-text'
-        },
-        {
-          key: 'cell-2-item-1',
-          className: 'cell-2-item-1-class',
-          children: 'cell-2-item-1-text'
-        },
-        {
-          key: 'cell-2-item-2',
-          className: 'cell-2-item-2-class',
-          children: 'cell-2-item-2-text'
-        }
-      ]
-    }
-  ]
-
   it('should set className for table tag', () => {
     const TEST_CLASS = 'TEST-CLASS'
 
@@ -130,7 +261,7 @@ describe('Table', () => {
     expect(rows).toHaveLength(5)
 
     expect(rows[0]).toHaveClass('header-0-class')
-    const row0headers = within(rows[0]).getAllByRole('columnheader')
+    const row0headers = within(rows[0]!).getAllByRole('columnheader')
     expect(row0headers).toHaveLength(3)
     expect(row0headers[0]).toHaveTextContent('header-0-item-0-text')
     expect(row0headers[0]).toHaveClass('header-0-item-0-class')
@@ -140,7 +271,7 @@ describe('Table', () => {
     expect(row0headers[2]).toHaveClass('header-0-item-2-class')
 
     expect(rows[1]).toHaveClass('header-1-class')
-    const row1headers = within(rows[1]).getAllByRole('columnheader')
+    const row1headers = within(rows[1]!).getAllByRole('columnheader')
     expect(row1headers).toHaveLength(3)
     expect(row1headers[0]).toHaveTextContent('header-1-item-0-text')
     expect(row1headers[0]).toHaveClass('header-1-item-0-class')
@@ -157,7 +288,7 @@ describe('Table', () => {
     expect(rows).toHaveLength(5)
 
     expect(rows[2]).toHaveClass('cell-0-class')
-    const row2cells = within(rows[2]).getAllByRole('cell')
+    const row2cells = within(rows[2]!).getAllByRole('cell')
     expect(row2cells).toHaveLength(3)
     expect(row2cells[0]).toHaveTextContent('cell-0-item-0-text')
     expect(row2cells[0]).toHaveClass('cell-0-item-0-class')
@@ -167,7 +298,7 @@ describe('Table', () => {
     expect(row2cells[2]).toHaveClass('cell-0-item-2-class')
 
     expect(rows[3]).toHaveClass('cell-1-class')
-    const row3cells = within(rows[3]).getAllByRole('cell')
+    const row3cells = within(rows[3]!).getAllByRole('cell')
     expect(row3cells).toHaveLength(3)
     expect(row3cells[0]).toHaveTextContent('cell-1-item-0-text')
     expect(row3cells[0]).toHaveClass('cell-1-item-0-class')
@@ -177,7 +308,7 @@ describe('Table', () => {
     expect(row3cells[2]).toHaveClass('cell-1-item-2-class')
 
     expect(rows[4]).toHaveClass('cell-2-class')
-    const row4cells = within(rows[4]).getAllByRole('cell')
+    const row4cells = within(rows[4]!).getAllByRole('cell')
     expect(row4cells).toHaveLength(3)
     expect(row4cells[0]).toHaveTextContent('cell-2-item-0-text')
     expect(row4cells[0]).toHaveClass('cell-2-item-0-class')

--- a/src/elements/table/types.ts
+++ b/src/elements/table/types.ts
@@ -1,0 +1,16 @@
+import type { HTMLAttributes, TdHTMLAttributes, ThHTMLAttributes } from 'react'
+
+export type TTableItem = {
+  key: string
+}
+
+export type TTableRow<T> = TTableItem &
+  Omit<HTMLAttributes<HTMLTableRowElement>, keyof TTableItem> & {
+    items: T[]
+  }
+
+export type TTableHeader = TTableItem &
+  Omit<ThHTMLAttributes<HTMLTableCellElement>, keyof TTableItem>
+
+export type TTableCell = TTableItem &
+  Omit<TdHTMLAttributes<HTMLTableCellElement>, keyof TTableItem>

--- a/src/elements/table/utils.test.ts
+++ b/src/elements/table/utils.test.ts
@@ -1,0 +1,42 @@
+import { getHighestColumnsLength } from './utils'
+
+describe('Table utils', () => {
+  describe('getHighestColumnsLength', () => {
+    it('should return 1 if headers param is empty', () => {
+      const headers: never[] = []
+
+      expect(getHighestColumnsLength(headers)).toBe(1)
+    })
+
+    it('should return 1 if there is no column', () => {
+      const headers = [
+        {
+          items: []
+        },
+        {
+          items: []
+        }
+      ]
+
+      // @ts-expect-error - I don't care about the type of items
+      expect(getHighestColumnsLength(headers)).toBe(1)
+    })
+
+    it('should return max column length', () => {
+      const headers = [
+        {
+          items: [1, 2, 3]
+        },
+        {
+          items: [1, 2, 3, 4]
+        },
+        {
+          items: [1, 2]
+        }
+      ]
+
+      // @ts-expect-error - I don't care about the type of items
+      expect(getHighestColumnsLength(headers)).toBe(4)
+    })
+  })
+})

--- a/src/elements/table/utils.ts
+++ b/src/elements/table/utils.ts
@@ -1,0 +1,16 @@
+import type { TTableHeader, TTableRow } from './types'
+
+/**
+ * @description - if headers is empty or items is empty, return 1
+ *
+ * @returns {number} - always > 0
+ */
+export const getHighestColumnsLength = (
+  headers: TTableRow<TTableHeader>[]
+): number => {
+  return (
+    (headers.length > 0
+      ? Math.max(...headers.map(({ items }) => items.length))
+      : 0) || 1
+  )
+}

--- a/src/modules/github/components/connections/connections.tsx
+++ b/src/modules/github/components/connections/connections.tsx
@@ -98,7 +98,8 @@ export const Connections: FC = () => {
                 children: translate('GITHUB.CONNECTION_TABLE_HEADER_CONNECTION')
               },
               {
-                key: 'header-cell-1 w-3',
+                key: 'header-cell-1',
+                className: 'w-3',
                 children: (
                   <Button
                     variant="ghost"
@@ -153,18 +154,7 @@ export const Connections: FC = () => {
                   }
                 ]
               }))
-            : [
-                {
-                  key: 'loading-header',
-                  items: [
-                    {
-                      key: 'loading-header-cell',
-                      children: 'Loading...',
-                      colSpan: 2
-                    }
-                  ]
-                }
-              ]
+            : undefined
         }
       />
 


### PR DESCRIPTION
## Issue Link

[issue-132](https://github.com/kafelix496/coding-for-fun/issues/132)

## Notes

@jskurt I feel like it's more complicated than I thought. So I just implemented this feature. You can just check this PR and tell me what you don't understand.